### PR TITLE
Registry version updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM registry:2.2.1
+FROM registry:2.3.0
 COPY config.yml /etc/docker/registry/config.yml


### PR DESCRIPTION
Docker registry 2.3.0 contains great improvements for the docker push command in terms to avoid unneeded uploads.
